### PR TITLE
Migrate to null-safety

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,21 +73,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,14 +99,14 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0"
   stepper_counter_swipe:
     dependency: "direct dev"
     description:
@@ -120,41 +120,41 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/lib/src/steppercounter.dart
+++ b/lib/src/steppercounter.dart
@@ -8,12 +8,12 @@ import 'package:flutter/physics.dart';
 /// i extended  the functionality to be more useful in real world applications
 class StepperSwipe extends StatefulWidget {
    StepperSwipe({
-    Key key,
-    @required this.initialValue,
+    Key? key,
+    required this.initialValue,
     @Deprecated('use minValue:0 instead')
     this.withNaturalNumbers = false,
     this.withBackground = true,
-    @required this.onChanged,
+    required this.onChanged,
     this.direction = Axis.horizontal,
     this.withSpring = true,
     this.counterTextColor = Colors.white,
@@ -26,7 +26,7 @@ class StepperSwipe extends StatefulWidget {
     this.maxValue=50,
     this.minValue=-50,
     this.withFastCount=false,
-    @required this.stepperValue,
+    required this.stepperValue,
 
 
   }) : super(key: key);
@@ -60,18 +60,19 @@ class StepperSwipe extends StatefulWidget {
 
 class _Stepper2State extends State<StepperSwipe>
     with SingleTickerProviderStateMixin {
-  AnimationController _controller;
-  Animation _animation;
-  int _value;
-  double _startAnimationPosX;
-  double _startAnimationPosY;
+  late AnimationController _controller;
+  late Animation<Offset> _animation;
+  late int _value;
+  double _startAnimationPosX = 0.0;
+  double _startAnimationPosY = 0.0;
   bool isTimerEnable = true;
   bool isReadyToFastAnim = true;
+
   @override
   void initState() {
     super.initState();
     widget.minValue = widget.withNaturalNumbers ? 0 : widget.minValue;
-    _value = widget.initialValue ?? 0;
+    _value = widget.initialValue;
     widget.stepperValue =_value;
     _controller =
         AnimationController(vsync: this, lowerBound: -0.5, upperBound: 0.5);
@@ -90,7 +91,7 @@ class _Stepper2State extends State<StepperSwipe>
 
   @override
   void dispose() {
-    _controller?.dispose();
+    _controller.dispose();
     super.dispose();
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,21 +66,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -92,55 +92,55 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ authors:
 homepage: https://github.com/burakozyurt/stepper_counter_swipe
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/test/steppercounterswipe_test.dart
+++ b/test/steppercounterswipe_test.dart
@@ -3,5 +3,5 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:stepper_counter_swipe/stepper_counter_swipe.dart';
 
 void main() {
-  StepperSwipe();
+  StepperSwipe(initialValue: 0, onChanged: (val) => {}, stepperValue: 1);
 }


### PR DESCRIPTION
Hey @burakozyurt,
I made some changes to support Dart's (somewhat) new sound null-safety.
This change doesn't break depending packages/apps since constructors and method signatures haven't changed significantly.

The only thing that you need to change is the package's version number. I didn't increment it since I'm not sure whether you would like to have it be version `2.0.0` or version `1.1.0` or anything else.

Thanks for the great work!